### PR TITLE
Dynamic attributes

### DIFF
--- a/docs/source/guide/basic.md
+++ b/docs/source/guide/basic.md
@@ -3,7 +3,7 @@
 !!! info "On this page"
     - GET/POST requests
     - Form and JSON
-    - Custom headers
+    - Custom headers, and the headers of a client
     - Query parameters & streaming
 
 This page covers the most common request patterns in wreq: sending GET and POST requests, working with form data and JSON, customizing headers, passing query parameters, and reading streaming responses.
@@ -153,6 +153,41 @@ Pass the `HeaderMap` to any request method via the `headers` argument:
 ```python
 response = await wreq.get("https://httpbin.org/headers", headers=headers)
 ```
+ 
+### Headers of a client
+ 
+A client sends its own headers with every request. They are given through the `headers`
+argument of the constructor, and can be changed at any time afterwards through the
+`headers` attribute:
+ 
+```python
+from wreq import Client
+ 
+client = Client(headers={"x-api-key": "secret"})
+ 
+# Add a header, or replace the value of one that is already there
+client.headers.update({"x-request-id": "1"})
+ 
+# Set, or remove, a single header
+client.headers["x-request-id"] = "2"
+del client.headers["x-request-id"]
+ 
+# Replace the headers of the client altogether
+client.headers = {"x-api-key": "another-secret"}
+```
+ 
+Reading the attribute gives back a `HeaderMap` bound to the client, so all of the usual
+lookups work on it too:
+ 
+```python
+print(client.headers["x-api-key"])
+# b'another-secret'
+```
+ 
+Every change rebuilds the client, keeping the rest of its configuration and its cookie
+jar: requests made afterwards carry the new headers, while the ones already in flight
+keep using the previous ones. Only the headers of the client are replaced, so those
+coming from an [emulation](emulation.md) are kept.
  
 ---
  

--- a/docs/source/guide/proxy.md
+++ b/docs/source/guide/proxy.md
@@ -109,7 +109,7 @@ async def main():
     client = Client(cookie_store=True)
 
     for url in POOL:
-        client.proxies = [Proxy.all(url)]
+        client.proxies = Proxy.all(url)
         resp = await client.get("https://httpbin.io/ip")
         print(await resp.text())
 
@@ -123,10 +123,18 @@ The rest of the client configuration — headers, emulation, timeouts, TLS optio
 cookie jar are kept across the change. Requests already in flight keep using the proxy they
 started with, and connections opened through the previous proxies are not reused.
 
-Reading the attribute returns the proxies currently in use, or `None` when there are none:
+Both the attribute and the `proxies=` argument of the constructor take either a single
+`Proxy` or a sequence of them, so the brackets can be dropped when there is only one:
 
 ```python
-client = Client(proxies=[Proxy.all("http://proxy.example.com:8080")])
+client = Client(proxies=Proxy.all("http://proxy.example.com:8080"))
+client.proxies = Proxy.all("http://other.example.com:8080")
+```
+
+Reading the attribute always gives back a list, or `None` when the client has no proxies:
+
+```python
+client = Client(proxies=Proxy.all("http://proxy.example.com:8080"))
 print(client.proxies)  # [<Proxy ...>]
 ```
 
@@ -140,7 +148,7 @@ from wreq.blocking import Client
 from wreq import Proxy
 
 client = Client()
-client.proxies = [Proxy.all("http://proxy.example.com:8080")]
+client.proxies = Proxy.all("http://proxy.example.com:8080")
 print(client.get("https://httpbin.io/ip").text())
 ```
 

--- a/docs/source/guide/proxy.md
+++ b/docs/source/guide/proxy.md
@@ -3,6 +3,7 @@
 !!! info "On this page"
     - HTTP/HTTPS proxy
     - Proxy with Authentication
+    - Changing the proxy of a client at runtime
     - Per-request proxy with custom headers
     - Unix Socket proxy for local services (Docker, Podman)
     - Constructor reference and choosing the right one
@@ -17,7 +18,7 @@ The `Proxy` class provides several constructors depending on what you want to in
 | `Proxy.unix(path)` | Requests via a Unix socket |
 
 You can pass a proxy in two ways:
-- **Per-client** via `Client(proxies=[...])` — applies to every request made by that client.
+- **Per-client** via `Client(proxies=[...])` — applies to every request made by that client, and can be changed at any time through the `proxies` attribute.
 - **Per-request** via `wreq.get(..., proxy=...)` — overrides or sets a proxy for a single request.
 
 ---
@@ -85,6 +86,63 @@ client = Client(
 ```
 
 > The difference between `socks5://` and `socks5h://` is that `socks5h` delegates DNS resolution to the proxy server, which helps avoid DNS leaks.
+
+---
+
+## Changing the proxy at runtime
+
+The proxies of a client are not frozen at construction time: assigning to the `proxies`
+attribute swaps them for every request made afterwards, which is handy to rotate through
+a pool of proxies while reusing the same client.
+
+```python
+import asyncio
+from wreq import Client, Proxy
+
+POOL = [
+    "http://proxy-1.example.com:8080",
+    "http://proxy-2.example.com:8080",
+    "http://proxy-3.example.com:8080",
+]
+
+async def main():
+    client = Client(cookie_store=True)
+
+    for url in POOL:
+        client.proxies = [Proxy.all(url)]
+        resp = await client.get("https://httpbin.io/ip")
+        print(await resp.text())
+
+    # Go back to the system proxy settings.
+    client.proxies = None
+
+asyncio.run(main())
+```
+
+The rest of the client configuration — headers, emulation, timeouts, TLS options — and its
+cookie jar are kept across the change. Requests already in flight keep using the proxy they
+started with, and connections opened through the previous proxies are not reused.
+
+Reading the attribute returns the proxies currently in use, or `None` when there are none:
+
+```python
+client = Client(proxies=[Proxy.all("http://proxy.example.com:8080")])
+print(client.proxies)  # [<Proxy ...>]
+```
+
+> **Note:** a client created with `no_proxy=True` never uses a proxy, just like when both
+> options are passed to the constructor.
+
+The same attribute is available on the blocking client:
+
+```python
+from wreq.blocking import Client
+from wreq import Proxy
+
+client = Client()
+client.proxies = [Proxy.all("http://proxy.example.com:8080")]
+print(client.get("https://httpbin.io/ip").text())
+```
 
 ---
 

--- a/examples/blocking/proxy.py
+++ b/examples/blocking/proxy.py
@@ -10,6 +10,11 @@ def main():
     )
     print(resp.text())
 
+    # Set the proxy of the client, so every request that follows goes through it
+    client.proxies = [Proxy.all("http://127.0.0.1:6152")]
+    resp = client.post("https://httpbin.io/anything")
+    print(resp.text())
+
 
 if __name__ == "__main__":
     main()

--- a/examples/blocking/proxy.py
+++ b/examples/blocking/proxy.py
@@ -11,7 +11,7 @@ def main():
     print(resp.text())
 
     # Set the proxy of the client, so every request that follows goes through it
-    client.proxies = [Proxy.all("http://127.0.0.1:6152")]
+    client.proxies = Proxy.all("http://127.0.0.1:6152")
     resp = client.post("https://httpbin.io/anything")
     print(resp.text())
 

--- a/examples/header_map.py
+++ b/examples/header_map.py
@@ -1,3 +1,4 @@
+from wreq import Client
 from wreq.header import HeaderMap
 
 if __name__ == "__main__":
@@ -23,3 +24,12 @@ if __name__ == "__main__":
     # Clear all headers
     headers.clear()
     print("After clear, is_empty:", headers.is_empty())
+
+    # The headers of a client can be changed after it has been created
+    client = Client(headers={"x-api-key": "secret"})
+    # Add a header, or replace the value of one that is already there
+    client.headers.update({"x-request-id": "1"})
+    print("Client headers:", client.headers)
+    # Replace the headers of the client altogether
+    client.headers = {"x-api-key": "another-secret"}
+    print("Client headers:", client.headers)

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -14,7 +14,7 @@ async def main():
     print(await resp.text())
 
     # Switch the client over to another proxy, without rebuilding it
-    client.proxies = [Proxy.all("http://127.0.0.1:6152")]
+    client.proxies = Proxy.all("http://127.0.0.1:6152")
     resp = await client.get("https://httpbin.io/anything")
     print(await resp.text())
 

--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -13,6 +13,11 @@ async def main():
     resp = await client.get("https://httpbin.io/anything")
     print(await resp.text())
 
+    # Switch the client over to another proxy, without rebuilding it
+    client.proxies = [Proxy.all("http://127.0.0.1:6152")]
+    resp = await client.get("https://httpbin.io/anything")
+    print(await resp.text())
+
     # Send request via custom proxy
     resp = await wreq.get(
         "https://httpbin.io/anything",

--- a/python/wreq/blocking.py
+++ b/python/wreq/blocking.py
@@ -1,12 +1,14 @@
 import datetime
 from typing import (
     Any,
+    Mapping,
     Sequence,
     Unpack,
 )
 
 from . import (
     ClientConfig,
+    ClientHeaders,
     Message,
     Method,
     Request,
@@ -219,6 +221,29 @@ class Client:
     Returns:
         - The provided `Jar` if the client was constructed with `cookie_provider=...`
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
+    """
+
+    headers: ClientHeaders | Mapping[str, str] | HeaderMap | None
+    r"""
+    Get or set the default headers sent with every request.
+
+    Reading gives back a `ClientHeaders`, a `HeaderMap` bound to this client: mutating
+    it, with `update()` for instance, applies the change to the requests made
+    afterwards.
+
+    Assigning rebuilds the client with the given headers, keeping the rest of its
+    configuration and its cookie jar, so the previously set headers are dropped while
+    the ones coming from the emulation are kept.
+
+    Examples:
+
+    ```python
+    import wreq
+
+    client = wreq.blocking.Client(headers={"x-api-key": "secret"})
+    client.headers.update({"x-request-id": "1"})
+    client.headers = {"x-api-key": "other"}
+    ```
     """
 
     proxies: Proxy | Sequence[Proxy] | None

--- a/python/wreq/blocking.py
+++ b/python/wreq/blocking.py
@@ -221,9 +221,12 @@ class Client:
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
     """
 
-    proxies: Sequence[Proxy] | None
+    proxies: Proxy | Sequence[Proxy] | None
     r"""
     Get or set the proxies used by this client.
+
+    A single `Proxy` or a sequence of them can be assigned; reading the attribute
+    always gives back a list, or `None` when the client has no proxies.
 
     Assigning a new value rebuilds the client with the given proxies, keeping the rest
     of its configuration and its cookie jar. Requests made afterwards go through the
@@ -239,7 +242,7 @@ class Client:
     import wreq
 
     client = wreq.blocking.Client(proxies=[wreq.Proxy.all("http://proxy.example.com:8080")])
-    client.proxies = [wreq.Proxy.all("http://other.example.com:8080")]
+    client.proxies = wreq.Proxy.all("http://other.example.com:8080")
     ```
     """
 

--- a/python/wreq/blocking.py
+++ b/python/wreq/blocking.py
@@ -18,6 +18,7 @@ from . import (
 )
 from .cookie import Cookie, Jar
 from .header import HeaderMap
+from .proxy import Proxy
 from .redirect import History
 from .tls import TlsInfo
 
@@ -218,6 +219,28 @@ class Client:
     Returns:
         - The provided `Jar` if the client was constructed with `cookie_provider=...`
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
+    """
+
+    proxies: Sequence[Proxy] | None
+    r"""
+    Get or set the proxies used by this client.
+
+    Assigning a new value rebuilds the client with the given proxies, keeping the rest
+    of its configuration and its cookie jar. Requests made afterwards go through the
+    new proxies, while the ones already in flight keep using the previous ones.
+    Assigning `None` restores the default behaviour of using the system proxies.
+
+    Note that a client created with `no_proxy=True` never uses a proxy, exactly like
+    when both options are given to the constructor.
+
+    Examples:
+
+    ```python
+    import wreq
+
+    client = wreq.blocking.Client(proxies=[wreq.Proxy.all("http://proxy.example.com:8080")])
+    client.proxies = [wreq.Proxy.all("http://other.example.com:8080")]
+    ```
     """
 
     def __init__(

--- a/python/wreq/header.py
+++ b/python/wreq/header.py
@@ -128,6 +128,18 @@ class HeaderMap:
         """
         ...
 
+    def update(self, headers: Mapping[str, str] | "HeaderMap") -> None:
+        r"""
+        Extend the map with the given headers.
+
+        The value of a header that is already present is replaced, and a header that
+        is missing is added.
+
+        Args:
+            headers: The headers to merge into the map
+        """
+        ...
+
     def remove(self, key: str) -> None:
         r"""
         Remove all values for a header name.

--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -1090,6 +1090,15 @@ class WebSocketRequest(TypedDict):
     """
 
 
+class ClientHeaders(HeaderMap):
+    r"""
+    The default headers of a `Client`.
+
+    This is a snapshot of the headers of the client it was taken from: mutating it
+    rebuilds that client, so that the change applies to the requests made afterwards.
+    """
+
+
 class Client:
     r"""
     A client for making HTTP requests.
@@ -1102,6 +1111,29 @@ class Client:
     Returns:
         - The provided `Jar` if the client was constructed with `cookie_provider=...`
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
+    """
+
+    headers: ClientHeaders | Mapping[str, str] | HeaderMap | None
+    r"""
+    Get or set the default headers sent with every request.
+
+    Reading gives back a `ClientHeaders`, a `HeaderMap` bound to this client: mutating
+    it, with `update()` for instance, applies the change to the requests made
+    afterwards.
+
+    Assigning rebuilds the client with the given headers, keeping the rest of its
+    configuration and its cookie jar, so the previously set headers are dropped while
+    the ones coming from the emulation are kept.
+
+    Examples:
+
+    ```python
+    import wreq
+
+    client = wreq.Client(headers={"x-api-key": "secret"})
+    client.headers.update({"x-request-id": "1"})
+    client.headers = {"x-api-key": "other"}
+    ```
     """
 
     proxies: Proxy | Sequence[Proxy] | None

--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -718,7 +718,7 @@ class ClientConfig(TypedDict):
     This also disables the automatic usage of the "system" proxy.
     """
 
-    proxies: NotRequired[Sequence[Proxy]]
+    proxies: NotRequired[Proxy | Sequence[Proxy]]
     """
     The proxies to use for requests.
     """
@@ -1104,9 +1104,12 @@ class Client:
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
     """
 
-    proxies: Sequence[Proxy] | None
+    proxies: Proxy | Sequence[Proxy] | None
     r"""
     Get or set the proxies used by this client.
+
+    A single `Proxy` or a sequence of them can be assigned; reading the attribute
+    always gives back a list, or `None` when the client has no proxies.
 
     Assigning a new value rebuilds the client with the given proxies, keeping the rest
     of its configuration and its cookie jar. Requests made afterwards go through the
@@ -1122,7 +1125,7 @@ class Client:
     import wreq
 
     client = wreq.Client(proxies=[wreq.Proxy.all("http://proxy.example.com:8080")])
-    client.proxies = [wreq.Proxy.all("http://other.example.com:8080")]
+    client.proxies = wreq.Proxy.all("http://other.example.com:8080")
     ```
     """
 

--- a/python/wreq/wreq.py
+++ b/python/wreq/wreq.py
@@ -1104,6 +1104,28 @@ class Client:
         - The auto-created `Jar` if the client was constructed with `cookie_store=True`
     """
 
+    proxies: Sequence[Proxy] | None
+    r"""
+    Get or set the proxies used by this client.
+
+    Assigning a new value rebuilds the client with the given proxies, keeping the rest
+    of its configuration and its cookie jar. Requests made afterwards go through the
+    new proxies, while the ones already in flight keep using the previous ones.
+    Assigning `None` restores the default behaviour of using the system proxies.
+
+    Note that a client created with `no_proxy=True` never uses a proxy, exactly like
+    when both options are given to the constructor.
+
+    Examples:
+
+    ```python
+    import wreq
+
+    client = wreq.Client(proxies=[wreq.Proxy.all("http://proxy.example.com:8080")])
+    client.proxies = [wreq.Proxy.all("http://other.example.com:8080")]
+    ```
+    """
+
     def __init__(
         self,
         **kwargs: Unpack[ClientConfig],

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ use crate::{
     emulate::EmulationLike,
     error::Error,
     extractor::Extractor,
-    header::{HeaderMap, OrigHeaderMap},
+    header::{HeaderMap, HeaderUpdate, OrigHeaderMap},
     http::Method,
     http1::Http1Options,
     http2::Http2Options,
@@ -762,11 +762,25 @@ impl BlockingClient {
 // ===== impl ClientHeaders =====
 
 impl ClientHeaders {
-    /// Pushes the headers of the view back onto the client they were taken from.
-    fn apply(slf: PyRefMut<'_, Self>, py: Python) -> PyResult<()> {
+    /// Applies an update to the headers of the client the view was taken from, and
+    /// refreshes the view with the result.
+    ///
+    /// The headers are read back under the rebuild lock of the client, rather than taken
+    /// from the view, so that concurrent updates cannot lose each other.
+    fn apply(mut slf: PyRefMut<'_, Self>, py: Python, update: HeaderUpdate) -> PyResult<()> {
         let client = slf.0.clone();
-        let headers = HeaderMap::clone(&slf.into_super());
-        client.set_headers(py, Some(headers))
+        let headers = py.detach(move || {
+            let _guard = client.lock();
+            let inner = client.inner.load();
+
+            let mut headers = inner.headers.clone().unwrap_or_default();
+            update.apply(&mut headers);
+            client.store(Some(headers.clone()), inner.proxies.clone())?;
+            PyResult::Ok(headers)
+        })?;
+
+        slf.as_super().0 = headers.0;
+        Ok(())
     }
 }
 
@@ -777,46 +791,41 @@ impl ClientHeaders {
     /// The value of a key that is already present is replaced, and a key that is missing
     /// is added.
     #[pyo3(signature = (headers))]
-    fn update(mut slf: PyRefMut<'_, Self>, py: Python, headers: HeaderMap) -> PyResult<()> {
-        slf.as_super().update(py, headers);
-        Self::apply(slf, py)
+    fn update(slf: PyRefMut<'_, Self>, py: Python, headers: HeaderMap) -> PyResult<()> {
+        Self::apply(slf, py, HeaderUpdate::Extend(headers))
     }
 
     /// Insert a key-value pair into the headers of the client.
     #[pyo3(signature = (key, value))]
     fn insert(
-        mut slf: PyRefMut<'_, Self>,
+        slf: PyRefMut<'_, Self>,
         py: Python,
         key: PyBackedStr,
         value: PyBackedStr,
     ) -> PyResult<()> {
-        slf.as_super().insert(py, key, value);
-        Self::apply(slf, py)
+        Self::apply(slf, py, HeaderUpdate::Insert(key, value))
     }
 
     /// Append a key-value pair to the headers of the client.
     #[pyo3(signature = (key, value))]
     fn append(
-        mut slf: PyRefMut<'_, Self>,
+        slf: PyRefMut<'_, Self>,
         py: Python,
         key: PyBackedStr,
         value: PyBackedStr,
     ) -> PyResult<()> {
-        slf.as_super().append(py, key, value);
-        Self::apply(slf, py)
+        Self::apply(slf, py, HeaderUpdate::Append(key, value))
     }
 
     /// Remove a key-value pair from the headers of the client.
     #[pyo3(signature = (key))]
-    fn remove(mut slf: PyRefMut<'_, Self>, py: Python, key: PyBackedStr) -> PyResult<()> {
-        slf.as_super().remove(py, key);
-        Self::apply(slf, py)
+    fn remove(slf: PyRefMut<'_, Self>, py: Python, key: PyBackedStr) -> PyResult<()> {
+        Self::apply(slf, py, HeaderUpdate::Remove(key))
     }
 
     /// Clears the headers of the client, removing all key-value pairs.
-    fn clear(mut slf: PyRefMut<'_, Self>, py: Python) -> PyResult<()> {
-        slf.as_super().clear();
-        Self::apply(slf, py)
+    fn clear(slf: PyRefMut<'_, Self>, py: Python) -> PyResult<()> {
+        Self::apply(slf, py, HeaderUpdate::Clear)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -320,6 +320,14 @@ impl Client {
             };
             config.cookie_provider = cookie_jar.clone();
 
+            // TLS options. The certificate is resolved upfront, so that the rebuilds of
+            // the client cannot fail on, nor pick up a change of, a certificate file.
+            config.tls_verify = config
+                .tls_verify
+                .take()
+                .map(TlsVerify::resolve)
+                .transpose()?;
+
             // Default headers and network options. Both are kept apart from the rest of
             // the configuration, since they can be replaced after the client is created.
             headers = config.headers.take();

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,9 +8,11 @@ mod query;
 
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::Arc,
     time::Duration,
 };
 
+use arc_swap::ArcSwap;
 use pyo3::{IntoPyObjectExt, coroutine::CancelHandle, prelude::*, pybacked::PyBackedStr};
 use req::{Request, WebSocketRequest};
 use tokio_util::sync::CancellationToken;
@@ -57,12 +59,12 @@ impl SocketAddr {
 impl_print_str!(Display, SocketAddr);
 
 /// A builder for `Client`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Builder {
     /// The Emulation settings for the client.
     emulation: Option<EmulationLike>,
     /// The user agent to use for the client.
-    user_agent: Option<PyBackedStr>,
+    user_agent: Option<String>,
     /// The headers to use for the client.
     headers: Option<HeaderMap>,
     /// The original headers to use for the client.
@@ -228,11 +230,22 @@ impl FromPyObject<'_, '_> for Builder {
     }
 }
 
+/// The swappable state of a `Client`.
+///
+/// The proxies are stored next to the `wreq::Client` they were built into, so that
+/// both are replaced at once whenever the proxies of the client are updated.
+#[derive(Default)]
+struct Inner {
+    client: wreq::Client,
+    proxies: Option<Vec<Proxy>>,
+}
+
 /// A client for making HTTP requests.
 #[derive(Default, Clone)]
 #[pyclass(subclass, frozen, skip_from_py_object)]
 pub struct Client {
-    inner: wreq::Client,
+    inner: Arc<ArcSwap<Inner>>,
+    config: Option<Arc<Builder>>,
     cancel: CancellationToken,
     raise_for_status: bool,
 
@@ -254,222 +267,60 @@ impl Client {
     #[new]
     #[pyo3(signature = (**kwds))]
     fn new(py: Python, kwds: Option<Builder>) -> PyResult<Client> {
+        let mut config = kwds;
+        let mut cookie_jar: Option<Jar> = None;
+        let mut proxies: Option<Vec<Proxy>> = None;
+        let mut raise_for_status = false;
+
+        if let Some(config) = config.as_mut() {
+            // Cookie options. The jar is resolved upfront, so that it survives the
+            // rebuilds of the client triggered by a proxy update.
+            cookie_jar = match config.cookie_provider.take() {
+                Some(jar) => Some(jar),
+                // `cookie_store` is true and no provider was given, so create a default jar to
+                // be accessed later through the client interface.
+                None => config.cookie_store.unwrap_or_default().then(Jar::new),
+            };
+            config.cookie_provider = cookie_jar.clone();
+
+            // Network options. The proxies are kept apart from the rest of the
+            // configuration, since they can be replaced after the client is created.
+            proxies = config.proxies.take();
+
+            raise_for_status = config.raise_for_status.unwrap_or(false);
+        }
+
+        py.detach(move || {
+            let client = build_client(config.clone(), proxies.clone())?;
+            Ok(Client {
+                inner: Arc::new(ArcSwap::from_pointee(Inner { client, proxies })),
+                config: config.map(Arc::new),
+                cancel: CancellationToken::new(),
+                raise_for_status,
+                cookie_jar,
+            })
+        })
+    }
+
+    /// Get the proxies of the client.
+    #[inline]
+    #[getter]
+    pub fn proxies(&self) -> Option<Vec<Proxy>> {
+        self.inner.load().proxies.clone()
+    }
+
+    /// Set the proxies of the client.
+    ///
+    /// The client is rebuilt with the given proxies, keeping the rest of its
+    /// configuration and its cookie jar. Requests made afterwards go through the new
+    /// proxies, while the ones already in flight keep using the previous ones. Setting
+    /// `None` restores the default behaviour of using the system proxies.
+    #[setter]
+    pub fn set_proxies(&self, py: Python, proxies: Option<Vec<Proxy>>) -> PyResult<()> {
         py.detach(|| {
-            // Create the client builder.
-            let mut builder = wreq::Client::builder();
-            let mut cookie_jar: Option<Jar> = None;
-            let mut raise_for_status = false;
-
-            if let Some(mut config) = kwds {
-                // Emulation options.
-                apply_option!(set_if_some, builder, config.emulation, emulation);
-
-                // User agent options.
-                apply_option!(
-                    set_if_some_map_ref,
-                    builder,
-                    config.user_agent,
-                    user_agent,
-                    AsRef::<str>::as_ref
-                );
-
-                // Default headers options.
-                apply_option!(set_if_some_inner, builder, config.headers, default_headers);
-                apply_option!(
-                    set_if_some_inner,
-                    builder,
-                    config.orig_headers,
-                    orig_headers
-                );
-
-                // Allow redirects options.
-                apply_option!(set_if_some, builder, config.referer, referer);
-                apply_option!(set_if_some_inner, builder, config.redirect, redirect);
-
-                // Cookie options.
-                if let Some(jar) = config.cookie_provider.take() {
-                    builder = builder.cookie_provider(jar.clone().0);
-                    cookie_jar = Some(jar);
-                } else if config.cookie_store.unwrap_or_default() {
-                    // `cookie_store` is true and no provider was given, so create a default jar to
-                    // be accessed later through the client interface.
-                    let jar = Jar::new();
-                    builder = builder.cookie_provider(jar.clone().0);
-                    cookie_jar = Some(jar);
-                }
-
-                // TCP options.
-                apply_option!(set_if_some, builder, config.tcp_keepalive, tcp_keepalive);
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.tcp_keepalive_interval,
-                    tcp_keepalive_interval
-                );
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.tcp_keepalive_retries,
-                    tcp_keepalive_retries
-                );
-                #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.tcp_user_timeout,
-                    tcp_user_timeout
-                );
-                apply_option!(set_if_some, builder, config.tcp_nodelay, tcp_nodelay);
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.tcp_reuse_address,
-                    tcp_reuse_address
-                );
-
-                // Timeout options.
-                apply_option!(set_if_some, builder, config.timeout, timeout);
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.connect_timeout,
-                    connect_timeout
-                );
-                apply_option!(set_if_some, builder, config.read_timeout, read_timeout);
-
-                // Pool options.
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.pool_idle_timeout,
-                    pool_idle_timeout
-                );
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.pool_max_idle_per_host,
-                    pool_max_idle_per_host
-                );
-                apply_option!(set_if_some, builder, config.pool_max_size, pool_max_size);
-
-                // Protocol options.
-                apply_option!(set_if_true, builder, config.http1_only, http1_only, false);
-                apply_option!(set_if_true, builder, config.http2_only, http2_only, false);
-                apply_option!(set_if_some, builder, config.https_only, https_only);
-                apply_option!(
-                    set_if_some_inner,
-                    builder,
-                    config.http1_options,
-                    http1_options
-                );
-                apply_option!(
-                    set_if_some_inner,
-                    builder,
-                    config.http2_options,
-                    http2_options
-                );
-
-                // TLS options.
-                apply_option!(
-                    set_if_some_map,
-                    builder,
-                    config.tls_min_version,
-                    tls_min_version,
-                    TlsVersion::into_ffi
-                );
-                apply_option!(
-                    set_if_some_map,
-                    builder,
-                    config.tls_max_version,
-                    tls_max_version,
-                    TlsVersion::into_ffi
-                );
-                apply_option!(set_if_some, builder, config.tls_info, tls_info);
-                apply_option!(
-                    set_if_some,
-                    builder,
-                    config.tls_verify_hostname,
-                    tls_verify_hostname
-                );
-                apply_option!(
-                    set_if_some_inner,
-                    builder,
-                    config.tls_identity,
-                    tls_identity
-                );
-                apply_option!(set_if_some_inner, builder, config.tls_keylog, tls_keylog);
-                apply_option!(set_if_some_inner, builder, config.tls_options, tls_options);
-                if let Some(verify) = config.tls_verify.take() {
-                    builder = match verify {
-                        TlsVerify::Verification(verify) => builder.tls_cert_verification(verify),
-                        TlsVerify::CertificatePath(path_buf) => {
-                            let pem_data = std::fs::read(path_buf)?;
-                            let store =
-                                CertStore::from_pem_stack(pem_data).map_err(Error::Library)?;
-                            builder.tls_cert_store(store)
-                        }
-                        TlsVerify::CertificateStore(cert_store) => {
-                            builder.tls_cert_store(cert_store.0)
-                        }
-                    }
-                }
-
-                // Network options.
-                apply_option!(set_if_some_iter_inner, builder, config.proxies, proxy);
-                apply_option!(set_if_true, builder, config.no_proxy, no_proxy, false);
-                apply_option!(set_if_some, builder, config.local_address, local_address);
-                apply_option!(
-                    set_if_some_tuple_inner,
-                    builder,
-                    config.local_addresses,
-                    local_addresses
-                );
-                #[cfg(any(
-                    target_os = "android",
-                    target_os = "fuchsia",
-                    target_os = "linux",
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos"
-                ))]
-                apply_option!(set_if_some, builder, config.interface, interface);
-
-                // DNS options.
-                if let Some(opts) = config.dns_options.take() {
-                    for (domain, addrs) in opts.resolve_to_addrs {
-                        builder = builder.resolve_to_addrs(domain.as_ref().to_string(), addrs);
-                    }
-
-                    if !opts.system_dns {
-                        builder =
-                            builder.dns_resolver(HickoryResolver::new(opts.lookup_ip_strategy));
-                    }
-                } else {
-                    builder =
-                        builder.dns_resolver(HickoryResolver::new(LookupIpStrategy::default()));
-                };
-
-                // Compression options.
-                apply_option!(set_if_some, builder, config.gzip, gzip);
-                apply_option!(set_if_some, builder, config.brotli, brotli);
-                apply_option!(set_if_some, builder, config.deflate, deflate);
-                apply_option!(set_if_some, builder, config.zstd, zstd);
-
-                raise_for_status = config.raise_for_status.unwrap_or(false);
-            }
-
-            builder
-                .build()
-                .map(|inner| Client {
-                    inner,
-                    cancel: CancellationToken::new(),
-                    cookie_jar,
-                    raise_for_status,
-                })
-                .map_err(Error::Library)
-                .map_err(Into::into)
+            let client = build_client(self.config.as_deref().cloned(), proxies.clone())?;
+            self.inner.store(Arc::new(Inner { client, proxies }));
+            Ok(())
         })
     }
 
@@ -643,6 +494,25 @@ impl BlockingClient {
         self.0.cookie_jar.clone()
     }
 
+    /// Get the proxies of the client.
+    #[inline]
+    #[getter]
+    pub fn proxies(&self) -> Option<Vec<Proxy>> {
+        self.0.proxies()
+    }
+
+    /// Set the proxies of the client.
+    ///
+    /// The client is rebuilt with the given proxies, keeping the rest of its
+    /// configuration and its cookie jar. Requests made afterwards go through the new
+    /// proxies, while the ones already in flight keep using the previous ones. Setting
+    /// `None` restores the default behaviour of using the system proxies.
+    #[inline]
+    #[setter]
+    pub fn set_proxies(&self, py: Python, proxies: Option<Vec<Proxy>>) -> PyResult<()> {
+        self.0.set_proxies(py, proxies)
+    }
+
     /// Close the client, preventing any new requests.
     #[inline]
     pub fn close(&self) {
@@ -794,4 +664,207 @@ impl BlockingClient {
     ) {
         self.close();
     }
+}
+
+/// Builds the underlying client from the given configuration and proxies.
+fn build_client(
+    config: Option<Builder>,
+    mut proxies: Option<Vec<Proxy>>,
+) -> PyResult<wreq::Client> {
+    // Create the client builder.
+    let mut builder = wreq::Client::builder();
+
+    // Network options. The proxies are applied apart from the configuration, so that
+    // they can be replaced on their own when the client is rebuilt.
+    apply_option!(set_if_some_iter_inner, builder, proxies, proxy);
+
+    if let Some(mut config) = config {
+        // Emulation options.
+        apply_option!(set_if_some, builder, config.emulation, emulation);
+
+        // User agent options.
+        apply_option!(
+            set_if_some_map_ref,
+            builder,
+            config.user_agent,
+            user_agent,
+            String::as_str
+        );
+
+        // Default headers options.
+        apply_option!(set_if_some_inner, builder, config.headers, default_headers);
+        apply_option!(
+            set_if_some_inner,
+            builder,
+            config.orig_headers,
+            orig_headers
+        );
+
+        // Allow redirects options.
+        apply_option!(set_if_some, builder, config.referer, referer);
+        apply_option!(set_if_some_inner, builder, config.redirect, redirect);
+
+        // Cookie options.
+        apply_option!(
+            set_if_some_inner,
+            builder,
+            config.cookie_provider,
+            cookie_provider
+        );
+
+        // TCP options.
+        apply_option!(set_if_some, builder, config.tcp_keepalive, tcp_keepalive);
+        apply_option!(
+            set_if_some,
+            builder,
+            config.tcp_keepalive_interval,
+            tcp_keepalive_interval
+        );
+        apply_option!(
+            set_if_some,
+            builder,
+            config.tcp_keepalive_retries,
+            tcp_keepalive_retries
+        );
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        apply_option!(
+            set_if_some,
+            builder,
+            config.tcp_user_timeout,
+            tcp_user_timeout
+        );
+        apply_option!(set_if_some, builder, config.tcp_nodelay, tcp_nodelay);
+        apply_option!(
+            set_if_some,
+            builder,
+            config.tcp_reuse_address,
+            tcp_reuse_address
+        );
+
+        // Timeout options.
+        apply_option!(set_if_some, builder, config.timeout, timeout);
+        apply_option!(
+            set_if_some,
+            builder,
+            config.connect_timeout,
+            connect_timeout
+        );
+        apply_option!(set_if_some, builder, config.read_timeout, read_timeout);
+
+        // Pool options.
+        apply_option!(
+            set_if_some,
+            builder,
+            config.pool_idle_timeout,
+            pool_idle_timeout
+        );
+        apply_option!(
+            set_if_some,
+            builder,
+            config.pool_max_idle_per_host,
+            pool_max_idle_per_host
+        );
+        apply_option!(set_if_some, builder, config.pool_max_size, pool_max_size);
+
+        // Protocol options.
+        apply_option!(set_if_true, builder, config.http1_only, http1_only, false);
+        apply_option!(set_if_true, builder, config.http2_only, http2_only, false);
+        apply_option!(set_if_some, builder, config.https_only, https_only);
+        apply_option!(
+            set_if_some_inner,
+            builder,
+            config.http1_options,
+            http1_options
+        );
+        apply_option!(
+            set_if_some_inner,
+            builder,
+            config.http2_options,
+            http2_options
+        );
+
+        // TLS options.
+        apply_option!(
+            set_if_some_map,
+            builder,
+            config.tls_min_version,
+            tls_min_version,
+            TlsVersion::into_ffi
+        );
+        apply_option!(
+            set_if_some_map,
+            builder,
+            config.tls_max_version,
+            tls_max_version,
+            TlsVersion::into_ffi
+        );
+        apply_option!(set_if_some, builder, config.tls_info, tls_info);
+        apply_option!(
+            set_if_some,
+            builder,
+            config.tls_verify_hostname,
+            tls_verify_hostname
+        );
+        apply_option!(
+            set_if_some_inner,
+            builder,
+            config.tls_identity,
+            tls_identity
+        );
+        apply_option!(set_if_some_inner, builder, config.tls_keylog, tls_keylog);
+        apply_option!(set_if_some_inner, builder, config.tls_options, tls_options);
+        if let Some(verify) = config.tls_verify.take() {
+            builder = match verify {
+                TlsVerify::Verification(verify) => builder.tls_cert_verification(verify),
+                TlsVerify::CertificatePath(path_buf) => {
+                    let pem_data = std::fs::read(path_buf)?;
+                    let store = CertStore::from_pem_stack(pem_data).map_err(Error::Library)?;
+                    builder.tls_cert_store(store)
+                }
+                TlsVerify::CertificateStore(cert_store) => builder.tls_cert_store(cert_store.0),
+            }
+        }
+
+        // Network options.
+        apply_option!(set_if_true, builder, config.no_proxy, no_proxy, false);
+        apply_option!(set_if_some, builder, config.local_address, local_address);
+        apply_option!(
+            set_if_some_tuple_inner,
+            builder,
+            config.local_addresses,
+            local_addresses
+        );
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "ios",
+            target_os = "visionos",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos"
+        ))]
+        apply_option!(set_if_some, builder, config.interface, interface);
+
+        // DNS options.
+        if let Some(opts) = config.dns_options.take() {
+            for (domain, addrs) in opts.resolve_to_addrs {
+                builder = builder.resolve_to_addrs(domain.as_ref().to_string(), addrs);
+            }
+
+            if !opts.system_dns {
+                builder = builder.dns_resolver(HickoryResolver::new(opts.lookup_ip_strategy));
+            }
+        } else {
+            builder = builder.dns_resolver(HickoryResolver::new(LookupIpStrategy::default()));
+        };
+
+        // Compression options.
+        apply_option!(set_if_some, builder, config.gzip, gzip);
+        apply_option!(set_if_some, builder, config.brotli, brotli);
+        apply_option!(set_if_some, builder, config.deflate, deflate);
+        apply_option!(set_if_some, builder, config.zstd, zstd);
+    }
+
+    builder.build().map_err(Error::Library).map_err(Into::into)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ mod query;
 
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
     time::Duration,
 };
 
@@ -232,11 +232,12 @@ impl FromPyObject<'_, '_> for Builder {
 
 /// The swappable state of a `Client`.
 ///
-/// The proxies are stored next to the `wreq::Client` they were built into, so that
-/// both are replaced at once whenever the proxies of the client are updated.
+/// The headers and the proxies are stored next to the `wreq::Client` they were built
+/// into, so that all of them are replaced at once whenever the client is updated.
 #[derive(Default)]
 struct Inner {
     client: wreq::Client,
+    headers: Option<HeaderMap>,
     proxies: Option<Vec<Proxy>>,
 }
 
@@ -246,6 +247,9 @@ struct Inner {
 pub struct Client {
     inner: Arc<ArcSwap<Inner>>,
     config: Option<Arc<Builder>>,
+    /// Serializes the rebuilds of the client, so that concurrent updates of its headers
+    /// and proxies cannot lose each other.
+    rebuild: Arc<Mutex<()>>,
     cancel: CancellationToken,
     raise_for_status: bool,
 
@@ -254,12 +258,44 @@ pub struct Client {
     cookie_jar: Option<Jar>,
 }
 
+/// The default headers of a `Client`.
+///
+/// This is a snapshot of the headers of the client it was taken from: mutating it
+/// rebuilds that client, so that the change applies to the requests made afterwards.
+#[pyclass(extends = HeaderMap, skip_from_py_object)]
+pub struct ClientHeaders(Client);
+
 /// A blocking client for making HTTP requests.
 #[derive(Default)]
 #[pyclass(name = "Client", subclass, frozen, skip_from_py_object)]
 pub struct BlockingClient(Client);
 
 // ====== Client =====
+
+impl Client {
+    /// Locks the client for a rebuild.
+    #[inline]
+    fn lock(&self) -> MutexGuard<'_, ()> {
+        self.rebuild.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Rebuilds the client with the given headers and proxies, keeping the rest of its
+    /// configuration. The client is left untouched when the rebuild fails.
+    fn store(&self, headers: Option<HeaderMap>, proxies: Option<Vec<Proxy>>) -> PyResult<()> {
+        let client = build_client(
+            self.config.as_deref().cloned(),
+            headers.clone(),
+            proxies.clone(),
+        )?;
+
+        self.inner.store(Arc::new(Inner {
+            client,
+            headers,
+            proxies,
+        }));
+        Ok(())
+    }
+}
 
 #[pymethods]
 impl Client {
@@ -269,6 +305,7 @@ impl Client {
     fn new(py: Python, kwds: Option<Builder>) -> PyResult<Client> {
         let mut config = kwds;
         let mut cookie_jar: Option<Jar> = None;
+        let mut headers: Option<HeaderMap> = None;
         let mut proxies: Option<Vec<Proxy>> = None;
         let mut raise_for_status = false;
 
@@ -283,22 +320,50 @@ impl Client {
             };
             config.cookie_provider = cookie_jar.clone();
 
-            // Network options. The proxies are kept apart from the rest of the
-            // configuration, since they can be replaced after the client is created.
+            // Default headers and network options. Both are kept apart from the rest of
+            // the configuration, since they can be replaced after the client is created.
+            headers = config.headers.take();
             proxies = config.proxies.take().map(|proxies| proxies.0);
 
             raise_for_status = config.raise_for_status.unwrap_or(false);
         }
 
         py.detach(move || {
-            let client = build_client(config.clone(), proxies.clone())?;
+            let client = build_client(config.clone(), headers.clone(), proxies.clone())?;
             Ok(Client {
-                inner: Arc::new(ArcSwap::from_pointee(Inner { client, proxies })),
+                inner: Arc::new(ArcSwap::from_pointee(Inner {
+                    client,
+                    headers,
+                    proxies,
+                })),
                 config: config.map(Arc::new),
+                rebuild: Arc::new(Mutex::new(())),
                 cancel: CancellationToken::new(),
                 raise_for_status,
                 cookie_jar,
             })
+        })
+    }
+
+    /// Get the default headers of the client.
+    #[getter]
+    pub fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, ClientHeaders>> {
+        let headers = self.inner.load().headers.clone().unwrap_or_default();
+        Bound::new(py, (ClientHeaders(self.clone()), headers))
+    }
+
+    /// Set the default headers of the client.
+    ///
+    /// The client is rebuilt with the given headers, keeping the rest of its
+    /// configuration and its cookie jar, so the previously set headers are dropped while
+    /// the ones coming from the emulation are kept. Requests made afterwards carry the
+    /// new headers, while the ones already in flight keep using the previous ones.
+    #[setter]
+    pub fn set_headers(&self, py: Python, headers: Option<HeaderMap>) -> PyResult<()> {
+        py.detach(|| {
+            let _guard = self.lock();
+            let proxies = self.inner.load().proxies.clone();
+            self.store(headers, proxies)
         })
     }
 
@@ -319,9 +384,9 @@ impl Client {
     pub fn set_proxies(&self, py: Python, proxies: Option<Proxies>) -> PyResult<()> {
         let proxies = proxies.map(|proxies| proxies.0);
         py.detach(|| {
-            let client = build_client(self.config.as_deref().cloned(), proxies.clone())?;
-            self.inner.store(Arc::new(Inner { client, proxies }));
-            Ok(())
+            let _guard = self.lock();
+            let headers = self.inner.load().headers.clone();
+            self.store(headers, proxies)
         })
     }
 
@@ -493,6 +558,25 @@ impl BlockingClient {
     #[getter]
     pub fn cookie_jar(&self) -> Option<Jar> {
         self.0.cookie_jar.clone()
+    }
+
+    /// Get the default headers of the client.
+    #[inline]
+    #[getter]
+    pub fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, ClientHeaders>> {
+        self.0.headers(py)
+    }
+
+    /// Set the default headers of the client.
+    ///
+    /// The client is rebuilt with the given headers, keeping the rest of its
+    /// configuration and its cookie jar, so the previously set headers are dropped while
+    /// the ones coming from the emulation are kept. Requests made afterwards carry the
+    /// new headers, while the ones already in flight keep using the previous ones.
+    #[inline]
+    #[setter]
+    pub fn set_headers(&self, py: Python, headers: Option<HeaderMap>) -> PyResult<()> {
+        self.0.set_headers(py, headers)
     }
 
     /// Get the proxies of the client.
@@ -667,9 +751,89 @@ impl BlockingClient {
     }
 }
 
-/// Builds the underlying client from the given configuration and proxies.
+// ===== impl ClientHeaders =====
+
+impl ClientHeaders {
+    /// Pushes the headers of the view back onto the client they were taken from.
+    fn apply(slf: PyRefMut<'_, Self>, py: Python) -> PyResult<()> {
+        let client = slf.0.clone();
+        let headers = HeaderMap::clone(&slf.into_super());
+        client.set_headers(py, Some(headers))
+    }
+}
+
+#[pymethods]
+impl ClientHeaders {
+    /// Extend the headers of the client with the given headers.
+    ///
+    /// The value of a key that is already present is replaced, and a key that is missing
+    /// is added.
+    #[pyo3(signature = (headers))]
+    fn update(mut slf: PyRefMut<'_, Self>, py: Python, headers: HeaderMap) -> PyResult<()> {
+        slf.as_super().update(py, headers);
+        Self::apply(slf, py)
+    }
+
+    /// Insert a key-value pair into the headers of the client.
+    #[pyo3(signature = (key, value))]
+    fn insert(
+        mut slf: PyRefMut<'_, Self>,
+        py: Python,
+        key: PyBackedStr,
+        value: PyBackedStr,
+    ) -> PyResult<()> {
+        slf.as_super().insert(py, key, value);
+        Self::apply(slf, py)
+    }
+
+    /// Append a key-value pair to the headers of the client.
+    #[pyo3(signature = (key, value))]
+    fn append(
+        mut slf: PyRefMut<'_, Self>,
+        py: Python,
+        key: PyBackedStr,
+        value: PyBackedStr,
+    ) -> PyResult<()> {
+        slf.as_super().append(py, key, value);
+        Self::apply(slf, py)
+    }
+
+    /// Remove a key-value pair from the headers of the client.
+    #[pyo3(signature = (key))]
+    fn remove(mut slf: PyRefMut<'_, Self>, py: Python, key: PyBackedStr) -> PyResult<()> {
+        slf.as_super().remove(py, key);
+        Self::apply(slf, py)
+    }
+
+    /// Clears the headers of the client, removing all key-value pairs.
+    fn clear(mut slf: PyRefMut<'_, Self>, py: Python) -> PyResult<()> {
+        slf.as_super().clear();
+        Self::apply(slf, py)
+    }
+}
+
+#[pymethods]
+impl ClientHeaders {
+    #[inline]
+    fn __setitem__(
+        slf: PyRefMut<'_, Self>,
+        py: Python,
+        key: PyBackedStr,
+        value: PyBackedStr,
+    ) -> PyResult<()> {
+        Self::insert(slf, py, key, value)
+    }
+
+    #[inline]
+    fn __delitem__(slf: PyRefMut<'_, Self>, py: Python, key: PyBackedStr) -> PyResult<()> {
+        Self::remove(slf, py, key)
+    }
+}
+
+/// Builds the underlying client from the given configuration, headers and proxies.
 fn build_client(
     config: Option<Builder>,
+    mut headers: Option<HeaderMap>,
     mut proxies: Option<Vec<Proxy>>,
 ) -> PyResult<wreq::Client> {
     // Create the client builder.
@@ -692,8 +856,7 @@ fn build_client(
             String::as_str
         );
 
-        // Default headers options.
-        apply_option!(set_if_some_inner, builder, config.headers, default_headers);
+        // Original headers options.
         apply_option!(
             set_if_some_inner,
             builder,
@@ -866,6 +1029,10 @@ fn build_client(
         apply_option!(set_if_some, builder, config.deflate, deflate);
         apply_option!(set_if_some, builder, config.zstd, zstd);
     }
+
+    // Default headers options. Applied apart from the configuration as well, but after
+    // it, so that they keep taking precedence over the headers set by the emulation.
+    apply_option!(set_if_some_inner, builder, headers, default_headers);
 
     builder.build().map_err(Error::Library).map_err(Into::into)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ use crate::{
     http::Method,
     http1::Http1Options,
     http2::Http2Options,
-    proxy::Proxy,
+    proxy::{Proxies, Proxy},
     redirect,
     tls::{Identity, KeyLog, TlsOptions, TlsVerify, TlsVersion},
 };
@@ -146,7 +146,7 @@ struct Builder {
     /// Whether to disable the proxy for the client.
     no_proxy: Option<bool>,
     /// The proxies to use for the client.
-    proxies: Option<Vec<Proxy>>,
+    proxies: Option<Proxies>,
     /// Bind to a local IP Address.
     local_address: Option<IpAddr>,
     /// Bind to local IP Addresses (IPv4, IPv6).
@@ -285,7 +285,7 @@ impl Client {
 
             // Network options. The proxies are kept apart from the rest of the
             // configuration, since they can be replaced after the client is created.
-            proxies = config.proxies.take();
+            proxies = config.proxies.take().map(|proxies| proxies.0);
 
             raise_for_status = config.raise_for_status.unwrap_or(false);
         }
@@ -316,7 +316,8 @@ impl Client {
     /// proxies, while the ones already in flight keep using the previous ones. Setting
     /// `None` restores the default behaviour of using the system proxies.
     #[setter]
-    pub fn set_proxies(&self, py: Python, proxies: Option<Vec<Proxy>>) -> PyResult<()> {
+    pub fn set_proxies(&self, py: Python, proxies: Option<Proxies>) -> PyResult<()> {
+        let proxies = proxies.map(|proxies| proxies.0);
         py.detach(|| {
             let client = build_client(self.config.as_deref().cloned(), proxies.clone())?;
             self.inner.store(Arc::new(Inner { client, proxies }));
@@ -509,7 +510,7 @@ impl BlockingClient {
     /// `None` restores the default behaviour of using the system proxies.
     #[inline]
     #[setter]
-    pub fn set_proxies(&self, py: Python, proxies: Option<Vec<Proxy>>) -> PyResult<()> {
+    pub fn set_proxies(&self, py: Python, proxies: Option<Proxies>) -> PyResult<()> {
         self.0.set_proxies(py, proxies)
     }
 

--- a/src/client/req.rs
+++ b/src/client/req.rs
@@ -294,7 +294,11 @@ where
     U: AsRef<str>,
 {
     // Create the request builder.
-    let mut builder = client.inner.request(method.into_ffi(), url.as_ref());
+    let mut builder = client
+        .inner
+        .load()
+        .client
+        .request(method.into_ffi(), url.as_ref());
 
     if let Some(mut request) = request {
         // Emulation options.
@@ -433,7 +437,7 @@ where
     U: AsRef<str>,
 {
     // Create the WebSocket builder.
-    let mut builder = client.inner.websocket(url.as_ref());
+    let mut builder = client.inner.load().client.websocket(url.as_ref());
 
     if let Some(mut request) = request {
         // Emulation options.

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -202,7 +202,7 @@ impl Emulation {
 }
 
 /// A helper enum to allow accepting either a Profile or an Emulation in the same parameter.
-#[derive(FromPyObject)]
+#[derive(Clone, FromPyObject)]
 pub enum EmulationLike {
     Profile(Profile),
     Emulation(Emulation),

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -3,6 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use pyo3::{FromPyObject, prelude::*};
 
 /// A generic extractor for various types.
+#[derive(Clone)]
 pub struct Extractor<T>(pub T);
 
 impl FromPyObject<'_, '_> for Extractor<(Option<Ipv4Addr>, Option<Ipv6Addr>)> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -18,6 +18,18 @@ pub struct HeaderMap(pub header::HeaderMap);
 #[pyclass(subclass, str, skip_from_py_object)]
 pub struct OrigHeaderMap(pub header::OrigHeaderMap);
 
+/// An update to apply to a `HeaderMap`.
+///
+/// A `Client` replays one of these onto its own headers, so that every operation has a
+/// single implementation whether it is applied to a plain map or to a client.
+pub enum HeaderUpdate {
+    Extend(HeaderMap),
+    Insert(PyBackedStr, PyBackedStr),
+    Append(PyBackedStr, PyBackedStr),
+    Remove(PyBackedStr),
+    Clear,
+}
+
 // ===== impl HeaderMap =====
 
 #[pymethods]
@@ -99,28 +111,14 @@ impl HeaderMap {
 
     /// Insert a key-value pair into the header map.
     #[pyo3(signature = (key, value))]
-    pub fn insert(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
-        py.detach(|| {
-            if let (Ok(name), Ok(value)) = (
-                HeaderName::from_bytes(key.as_bytes()),
-                HeaderValue::from_maybe_shared(Bytes::from_owner(value)),
-            ) {
-                self.0.insert(name, value);
-            }
-        })
+    fn insert(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
+        py.detach(|| HeaderUpdate::Insert(key, value).apply(self))
     }
 
     /// Append a key-value pair to the header map.
     #[pyo3(signature = (key, value))]
-    pub fn append(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
-        py.detach(|| {
-            if let (Ok(name), Ok(value)) = (
-                HeaderName::from_bytes(key.as_bytes()),
-                HeaderValue::from_maybe_shared(Bytes::from_owner(value)),
-            ) {
-                self.0.append(name, value);
-            }
-        })
+    fn append(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
+        py.detach(|| HeaderUpdate::Append(key, value).apply(self))
     }
 
     /// Extend the header map with the given headers.
@@ -128,16 +126,14 @@ impl HeaderMap {
     /// The value of a key that is already present is replaced, and a key that is missing
     /// is added.
     #[pyo3(signature = (headers))]
-    pub fn update(&mut self, py: Python, headers: HeaderMap) {
-        py.detach(|| self.0.extend(headers.0))
+    fn update(&mut self, py: Python, headers: HeaderMap) {
+        py.detach(|| HeaderUpdate::Extend(headers).apply(self))
     }
 
     /// Remove a key-value pair from the header map.
     #[pyo3(signature = (key))]
-    pub fn remove(&mut self, py: Python, key: PyBackedStr) {
-        py.detach(|| {
-            self.0.remove::<&str>(key.as_ref());
-        })
+    fn remove(&mut self, py: Python, key: PyBackedStr) {
+        py.detach(|| HeaderUpdate::Remove(key).apply(self))
     }
 
     /// Returns true if the map contains a value for the specified key.
@@ -197,8 +193,8 @@ impl HeaderMap {
 
     /// Clears the map, removing all key-value pairs. Keeps the allocated memory for reuse.
     #[inline]
-    pub fn clear(&mut self) {
-        self.0.clear();
+    fn clear(&mut self) {
+        HeaderUpdate::Clear.apply(self)
     }
 }
 
@@ -272,6 +268,42 @@ impl FromPyObject<'_, '_> for HeaderMap {
                 },
             )
             .map(Self)
+    }
+}
+
+// ===== impl HeaderUpdate =====
+
+impl HeaderUpdate {
+    /// Applies the update to the given headers, ignoring an invalid header name or value.
+    pub fn apply(self, headers: &mut HeaderMap) {
+        match self {
+            HeaderUpdate::Extend(other) => headers.0.extend(other.0),
+            HeaderUpdate::Insert(key, value) => {
+                if let Some((name, value)) = header_pair(key, value) {
+                    headers.0.insert(name, value);
+                }
+            }
+            HeaderUpdate::Append(key, value) => {
+                if let Some((name, value)) = header_pair(key, value) {
+                    headers.0.append(name, value);
+                }
+            }
+            HeaderUpdate::Remove(key) => {
+                headers.0.remove::<&str>(key.as_ref());
+            }
+            HeaderUpdate::Clear => headers.0.clear(),
+        }
+    }
+}
+
+/// Converts a key-value pair into a header name and value, discarding an invalid one.
+fn header_pair(key: PyBackedStr, value: PyBackedStr) -> Option<(HeaderName, HeaderValue)> {
+    match (
+        HeaderName::from_bytes(key.as_bytes()),
+        HeaderValue::from_maybe_shared(Bytes::from_owner(value)),
+    ) {
+        (Ok(name), Ok(value)) => Some((name, value)),
+        _ => None,
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -9,7 +9,7 @@ use wreq::header::{self, HeaderName, HeaderValue};
 use crate::{buffer::PyBuffer, error::Error};
 
 /// A HTTP header map.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[pyclass(subclass, str, skip_from_py_object)]
 pub struct HeaderMap(pub header::HeaderMap);
 
@@ -99,7 +99,7 @@ impl HeaderMap {
 
     /// Insert a key-value pair into the header map.
     #[pyo3(signature = (key, value))]
-    fn insert(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
+    pub fn insert(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
         py.detach(|| {
             if let (Ok(name), Ok(value)) = (
                 HeaderName::from_bytes(key.as_bytes()),
@@ -112,7 +112,7 @@ impl HeaderMap {
 
     /// Append a key-value pair to the header map.
     #[pyo3(signature = (key, value))]
-    fn append(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
+    pub fn append(&mut self, py: Python, key: PyBackedStr, value: PyBackedStr) {
         py.detach(|| {
             if let (Ok(name), Ok(value)) = (
                 HeaderName::from_bytes(key.as_bytes()),
@@ -123,9 +123,18 @@ impl HeaderMap {
         })
     }
 
+    /// Extend the header map with the given headers.
+    ///
+    /// The value of a key that is already present is replaced, and a key that is missing
+    /// is added.
+    #[pyo3(signature = (headers))]
+    pub fn update(&mut self, py: Python, headers: HeaderMap) {
+        py.detach(|| self.0.extend(headers.0))
+    }
+
     /// Remove a key-value pair from the header map.
     #[pyo3(signature = (key))]
-    fn remove(&mut self, py: Python, key: PyBackedStr) {
+    pub fn remove(&mut self, py: Python, key: PyBackedStr) {
         py.detach(|| {
             self.0.remove::<&str>(key.as_ref());
         })
@@ -188,7 +197,7 @@ impl HeaderMap {
 
     /// Clears the map, removing all key-value pairs. Keeps the allocated memory for reuse.
     #[inline]
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.0.clear();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod redirect;
 mod tls;
 
 use client::{
-    BlockingClient, Client, SocketAddr,
+    BlockingClient, Client, ClientHeaders, SocketAddr,
     body::{
         Streamer,
         multipart::{Multipart, Part},
@@ -341,6 +341,7 @@ fn wreq(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Part>()?;
     m.add_class::<Multipart>()?;
     m.add_class::<Client>()?;
+    m.add_class::<ClientHeaders>()?;
     m.add_class::<Response>()?;
     m.add_class::<WebSocket>()?;
     m.add_class::<Streamer>()?;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -29,6 +29,10 @@ struct Builder {
 #[pyclass(subclass, frozen, str, from_py_object)]
 pub struct Proxy(pub wreq::Proxy);
 
+/// A helper struct to allow parsing either a single proxy or a sequence of proxies.
+#[derive(Clone)]
+pub struct Proxies(pub Vec<Proxy>);
+
 // ===== impl Builder =====
 
 impl FromPyObject<'_, '_> for Builder {
@@ -94,6 +98,20 @@ impl Proxy {
 }
 
 impl_print_str!(Debug, Proxy);
+
+// ===== impl Proxies =====
+
+impl FromPyObject<'_, '_> for Proxies {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<PyAny>) -> PyResult<Self> {
+        if let Ok(proxy) = ob.extract::<Proxy>() {
+            return Ok(Proxies(vec![proxy]));
+        }
+
+        ob.extract::<Vec<Proxy>>().map(Proxies)
+    }
+}
 
 fn create_proxy<'py>(
     py: Python<'py>,

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -20,7 +20,7 @@ define_enum!(
     TLS_1_3,
 );
 
-#[derive(FromPyObject)]
+#[derive(Clone, FromPyObject)]
 pub enum TlsVerify {
     Verification(bool),
     CertificatePath(std::path::PathBuf),

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -7,7 +7,7 @@ use wreq::tls::compress::CertificateCompressor;
 use wreq_util::emulate::compress;
 
 pub use self::{identity::Identity, keylog::KeyLog, store::CertStore};
-use crate::buffer::PyBuffer;
+use crate::{buffer::PyBuffer, error::Error};
 
 define_enum!(
     /// The TLS version.
@@ -25,6 +25,30 @@ pub enum TlsVerify {
     Verification(bool),
     CertificatePath(std::path::PathBuf),
     CertificateStore(CertStore),
+}
+
+// ===== impl TlsVerify =====
+
+impl TlsVerify {
+    /// Reads a certificate file into a certificate store, leaving the other variants
+    /// untouched.
+    ///
+    /// A `Client` resolves its certificate once, so that the rebuilds it goes through
+    /// neither read the file again nor pick up a certificate that has been swapped in
+    /// the meantime.
+    pub fn resolve(self) -> PyResult<Self> {
+        match self {
+            TlsVerify::CertificatePath(path) => {
+                let pem_data = std::fs::read(path)?;
+                wreq::tls::trust::CertStore::from_pem_stack(pem_data)
+                    .map(CertStore)
+                    .map(TlsVerify::CertificateStore)
+                    .map_err(Error::Library)
+                    .map_err(Into::into)
+            }
+            verify => Ok(verify),
+        }
+    }
 }
 
 define_enum!(

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -1,5 +1,43 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
 import pytest
+import wreq
+from wreq import Client
+from wreq.emulation import Emulation
 from wreq.header import OrigHeaderMap, HeaderMap
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    r"""Answers every request with the headers it received."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        body = json.dumps(
+            {name.lower(): value for name, value in self.headers.items()}
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def echo():
+    r"""An echo server listening on the loopback interface."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+
+    server.shutdown()
+    server.server_close()
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
@@ -161,3 +199,116 @@ def test_init_with_dict():
     assert not h.is_empty()
     assert h.contains_key("A")
     assert h.contains_key("B")
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
+def test_update():
+    h = HeaderMap({"A": "1", "B": "2"})
+    h.update({"B": "22", "C": "3"})
+    assert h["A"] == b"1"
+    assert h["B"] == b"22"
+    assert h["C"] == b"3"
+    assert h.keys_len() == 3
+
+    # The values of a multi-value key replace the ones already stored.
+    other = HeaderMap()
+    other.insert("A", "10")
+    other.append("A", "11")
+    h.update(other)
+    assert list(h.get_all("A")) == [b"10", b"11"]
+
+
+def test_client_headers(echo):
+    client = Client(headers={"x-one": "1"})
+    headers = client.headers
+    assert isinstance(headers, HeaderMap)
+    assert headers["x-one"] == b"1"
+    assert len(headers) == 1
+
+    client.headers = None
+    assert len(client.headers) == 0
+
+
+@pytest.mark.asyncio
+async def test_client_set_headers(echo):
+    client = Client(headers={"x-one": "1", "x-two": "2"})
+
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert sent["x-one"] == "1"
+        assert sent["x-two"] == "2"
+
+    # Assigning replaces the headers of the client rather than merging into them.
+    client.headers = {"x-three": "3"}
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert sent["x-three"] == "3"
+        assert "x-one" not in sent
+        assert "x-two" not in sent
+
+
+@pytest.mark.asyncio
+async def test_client_update_headers(echo):
+    client = Client(headers={"x-one": "1"})
+
+    client.headers.update({"x-one": "11", "x-two": "2"})
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert sent["x-one"] == "11"
+        assert sent["x-two"] == "2"
+
+    client.headers["x-three"] = "3"
+    del client.headers["x-two"]
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert sent["x-three"] == "3"
+        assert "x-two" not in sent
+
+    client.headers.clear()
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert "x-one" not in sent
+        assert "x-three" not in sent
+
+
+@pytest.mark.asyncio
+async def test_client_headers_keep_emulation(echo):
+    client = Client(emulation=Emulation.Chrome133, headers={"x-one": "1"})
+
+    resp = await client.get(echo)
+    async with resp:
+        user_agent = (await resp.json())["user-agent"]
+
+    # Only the headers of the client are replaced, the ones coming from the emulation
+    # are kept.
+    client.headers.update({"x-one": "11"})
+    resp = await client.get(echo)
+    async with resp:
+        sent = await resp.json()
+        assert sent["x-one"] == "11"
+        assert sent["user-agent"] == user_agent
+
+
+@pytest.mark.asyncio
+async def test_client_headers_reused_by_another_client(echo):
+    client = Client(headers={"x-one": "1"})
+    other = Client(headers=client.headers)
+
+    resp = await other.get(echo)
+    async with resp:
+        assert (await resp.json())["x-one"] == "1"
+
+
+def test_blocking_client_headers(echo):
+    client = wreq.blocking.Client(headers={"x-one": "1"})
+    client.headers.update({"x-two": "2"})
+
+    with client.get(echo) as resp:
+        sent = resp.json()
+        assert sent["x-one"] == "1"
+        assert sent["x-two"] == "2"

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -304,6 +304,25 @@ async def test_client_headers_reused_by_another_client(echo):
         assert (await resp.json())["x-one"] == "1"
 
 
+def test_client_headers_concurrent_updates():
+    # Every thread updates a header of its own, so an update lost to another thread
+    # shows up as a missing key rather than as an unexpected value.
+    client = Client()
+
+    def worker(index):
+        for _ in range(20):
+            client.headers.update({f"x-{index}": str(index)})
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    headers = client.headers
+    assert [headers[f"x-{index}"] for index in range(4)] == [b"0", b"1", b"2", b"3"]
+
+
 def test_blocking_client_headers(echo):
     client = wreq.blocking.Client(headers={"x-one": "1"})
     client.headers.update({"x-two": "2"})

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -218,7 +218,7 @@ def test_update():
     assert list(h.get_all("A")) == [b"10", b"11"]
 
 
-def test_client_headers(echo):
+def test_client_headers():
     client = Client(headers={"x-one": "1"})
     headers = client.headers
     assert isinstance(headers, HeaderMap)

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -73,6 +73,32 @@ def test_client_proxies(servers):
     assert client.proxies is None
 
 
+def test_client_proxies_accept_a_single_proxy(servers):
+    # A lone `Proxy` is accepted wherever a sequence of them is, and is read back as a
+    # single element list.
+    client = Client(proxies=Proxy.all(servers["first"]))
+    assert client.proxies is not None
+    assert len(client.proxies) == 1
+
+    client.proxies = Proxy.all(servers["second"])
+    assert client.proxies is not None
+    assert len(client.proxies) == 1
+
+
+@pytest.mark.asyncio
+async def test_client_switch_to_a_single_proxy(servers):
+    client = Client(proxies=Proxy.all(servers["first"]))
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "first"
+
+    client.proxies = Proxy.all(servers["second"])
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "second"
+
+
 @pytest.mark.asyncio
 async def test_client_switch_proxies(servers):
     client = Client(proxies=[Proxy.all(servers["first"])])

--- a/tests/proxy_test.py
+++ b/tests/proxy_test.py
@@ -1,0 +1,177 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+import wreq
+from wreq import Client, Proxy
+
+
+class _Handler(BaseHTTPRequestHandler):
+    r"""Answers every request with the label of the server that handled it.
+
+    Used both as an origin server and as a forward proxy: a proxied request is
+    answered by the proxy itself, so the label tells which one was reached.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        body = json.dumps(
+            {
+                "server": self.server.label,
+                "url": self.path,
+                "headers": {
+                    name.lower(): value for name, value in self.headers.items()
+                },
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("set-cookie", "flavor=chocolate; Path=/")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def servers():
+    r"""An origin server and two proxies, all listening on the loopback interface."""
+    servers = {}
+    for label in ("origin", "first", "second"):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        server.label = label
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        servers[label] = server
+
+    yield {
+        label: f"http://127.0.0.1:{server.server_address[1]}"
+        for label, server in servers.items()
+    }
+
+    for server in servers.values():
+        server.shutdown()
+        server.server_close()
+
+
+def test_client_proxies(servers):
+    client = Client()
+    assert client.proxies is None
+
+    client = Client(proxies=[Proxy.all(servers["first"])])
+    assert client.proxies is not None
+    assert len(client.proxies) == 1
+
+    client.proxies = [Proxy.all(servers["first"]), Proxy.all(servers["second"])]
+    assert client.proxies is not None
+    assert len(client.proxies) == 2
+
+    client.proxies = None
+    assert client.proxies is None
+
+
+@pytest.mark.asyncio
+async def test_client_switch_proxies(servers):
+    client = Client(proxies=[Proxy.all(servers["first"])])
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "first"
+
+    client.proxies = [Proxy.all(servers["second"])]
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "second"
+
+    client.proxies = None
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "origin"
+
+
+@pytest.mark.asyncio
+async def test_client_switch_proxies_without_config(servers):
+    client = Client()
+    client.proxies = [Proxy.all(servers["first"])]
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_client_switch_scheme_specific_proxies(servers):
+    client = Client(
+        proxies=[Proxy.https(servers["first"]), Proxy.http(servers["second"])]
+    )
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "second"
+
+    client.proxies = [Proxy.http(servers["first"]), Proxy.https(servers["second"])]
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert (await resp.json())["server"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_client_switch_proxies_keeps_config(servers):
+    client = Client(user_agent="wreq-test", proxies=[Proxy.all(servers["first"])])
+    client.proxies = [Proxy.all(servers["second"])]
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        body = await resp.json()
+        assert body["server"] == "second"
+        assert body["headers"]["user-agent"] == "wreq-test"
+
+
+@pytest.mark.asyncio
+async def test_client_switch_proxies_keeps_cookie_jar(servers):
+    client = Client(cookie_store=True, proxies=[Proxy.all(servers["first"])])
+
+    resp = await client.get(servers["origin"])
+    async with resp:
+        assert resp.status.is_success()
+
+    client.proxies = [Proxy.all(servers["second"])]
+    assert client.cookie_jar is not None
+    assert any(cookie.name == "flavor" for cookie in client.cookie_jar.get_all())
+
+    # The cookie stored while going through the first proxy is still sent once the
+    # client has been switched over to the second one.
+    resp = await client.get(servers["origin"])
+    async with resp:
+        body = await resp.json()
+        assert body["server"] == "second"
+        assert body["headers"]["cookie"] == "flavor=chocolate"
+
+
+@pytest.mark.asyncio
+async def test_request_proxy_overrides_client_proxies(servers):
+    client = Client(proxies=[Proxy.all(servers["first"])])
+
+    resp = await client.get(servers["origin"], proxy=Proxy.all(servers["second"]))
+    async with resp:
+        assert (await resp.json())["server"] == "second"
+
+
+def test_blocking_client_switch_proxies(servers):
+    client = wreq.blocking.Client(proxies=[Proxy.all(servers["first"])])
+    assert client.proxies is not None
+    assert len(client.proxies) == 1
+
+    with client.get(servers["origin"]) as resp:
+        assert resp.json()["server"] == "first"
+
+    client.proxies = [Proxy.all(servers["second"])]
+    with client.get(servers["origin"]) as resp:
+        assert resp.json()["server"] == "second"
+
+    client.proxies = None
+    with client.get(servers["origin"]) as resp:
+        assert resp.json()["server"] == "origin"

--- a/tests/tls_test.py
+++ b/tests/tls_test.py
@@ -48,3 +48,17 @@ async def test_alps_new_endpoint():
     async with resp:
         text = await resp.text()
         assert text is not None
+
+
+def test_client_tls_verify_path_read_once(tmp_path):
+    # The certificate file is read once, when the client is created, so updating the
+    # client afterwards neither reads it again nor fails once the file is gone.
+    cert = tmp_path / "ca.pem"
+    cert.write_text("")
+    client = wreq.Client(tls_verify=cert)
+
+    cert.unlink()
+    client.headers.update({"x-one": "1"})
+    client.proxies = None
+
+    assert client.headers["x-one"] == b"1"


### PR DESCRIPTION
## Dynamic `headers` and `proxies` on an instantiated client

  Both settings could only be given to the constructor and were fixed for the life of the
  client. They are now readable and writable attributes on `Client` and
  `blocking.Client`.

  ```python
  client = Client(headers={"x-api-key": "secret"}, proxies=Proxy.all("http://a:8080"))

  client.proxies = Proxy.all("http://b:8080")     # a single proxy or a sequence
  client.proxies = None                            # back to the system proxies

  client.headers.update({"x-request-id": "1"})     # add, or replace what is there
  client.headers["x-trace"] = "abc"
  del client.headers["x-trace"]
  client.headers = {"x-api-key": "other"}          # replace them altogether
  ```

  - `proxies` reads back as a list, or `None`. `Proxy.all(...)` is accepted wherever a
    sequence is, on the attribute and on the constructor argument alike.
  - `headers` reads back a `ClientHeaders`, a `HeaderMap` bound to the client, so the
    usual lookups work on it and it can be handed to another client. `HeaderMap.update()`
    is new and available on plain maps too.
  - Changing either keeps the rest of the configuration and the cookie jar. Only the
    headers of the client are replaced, so those coming from an emulation are kept.
    Requests already in flight keep the settings they started with.

  ### Implementation

  `wreq::Client` bakes default headers and proxies in at build time, so a change rebuilds
  the underlying client from the retained configuration and swaps it in through an
  `ArcSwap`. The request path stays lock-free; a mutex serializes the rebuilds so that
  concurrent updates of the headers and the proxies cannot lose each other. Dropping the
  old connection pool is intended: connections opened through the previous proxy are not
  reused.

  Two details worth flagging for review:

  - `Builder.user_agent` moved from `PyBackedStr` to `String`, because `PyBackedStr` is not
    `Clone` in pyo3 0.29 and the retained configuration has to be cloneable. One small
    allocation per client build.
  - A `tls_verify` certificate file is now read once, at construction, rather than on every
    rebuild.

  ### Tests

  `tests/proxy_test.py` and the client half of `tests/header_test.py` are hermetic — local
  servers standing in for the origin and for two forward proxies, no network. They cover
  switching, clearing, scheme-specific proxy lists, per-request override, configuration and
  cookie-jar preservation, emulation headers surviving a header change, concurrent updates
  from threads, and the blocking client.