### PR TITLE
feat(emulate): expose Chrome 150/151/152 and chromium_root_store()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ abi3-py311 = ["pyo3/abi3-py311"]
 abi3-py313 = ["pyo3/abi3-py313"]
 abi3-py314 = ["pyo3/abi3-py314"]
 
+chromium-pki = ["wreq-util/emulation-chromium-pki"]
+
 [dependencies]
 tokio = "1.52.2"
 tokio-util = "0.7.18"

--- a/python/wreq/tls.py
+++ b/python/wreq/tls.py
@@ -19,6 +19,7 @@ __all__ = [
     "ExtensionType",
     "TlsOptions",
     "TlsInfo",
+    "chromium_root_store",
     "Params",
     "KeyShare",
 ]
@@ -451,3 +452,14 @@ class TlsInfo:
         Get the DER encoded leaf certificate of the peer.
         """
         ...
+
+
+def chromium_root_store() -> CertStore:
+    """
+    Chrome's root store from chromium-root-certs, for a client's `tls_verify`.
+
+    Chrome 150+ requests specific trust anchors and a server may return a chain anchored to one
+    of them, so the client needs Chrome's roots to verify it. Backed only when wreq was built with
+    the `chromium-pki` feature; without it this function exists but raises RuntimeError.
+    """
+    ...

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -50,6 +50,9 @@ define_enum!(
     Chrome147,
     Chrome148,
     Chrome149,
+    Chrome150,
+    Chrome151,
+    Chrome152,
 
     Edge101,
     Edge122,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,25 @@ pub async fn websocket(
     Client::default().websocket(cancel, url, kwds).await
 }
 
+/// Chrome's root store from chromium-root-certs, for a client's `tls_verify`.
+/// Chrome 150+ requests specific trust anchors and a server may return a chain
+/// anchored to one of them, so the client needs Chrome's roots to verify it.
+/// Only backed when wreq was built with the `chromium-pki` feature; without it
+/// the function still exists but raises, rather than being silently absent.
+#[pyfunction]
+fn chromium_root_store() -> PyResult<CertStore> {
+    #[cfg(feature = "chromium-pki")]
+    {
+        Ok(CertStore(wreq_util::chromium_root_store()))
+    }
+    #[cfg(not(feature = "chromium-pki"))]
+    {
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "wreq was built without the chromium-pki feature",
+        ))
+    }
+}
+
 #[pymodule(gil_used = false)]
 fn wreq(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     use r#async::{delete, get, head, options, patch, post, put, request, trace, websocket};
@@ -450,6 +469,7 @@ fn tls_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ExtensionType>()?;
     m.add_class::<TlsOptions>()?;
     m.add_class::<TlsInfo>()?;
+    m.add_function(wrap_pyfunction!(chromium_root_store, m)?)?;
     Ok(())
 }
 

--- a/tests/tls_test.py
+++ b/tests/tls_test.py
@@ -1,7 +1,7 @@
 import pytest
 import wreq
 from wreq.emulation import Emulation
-from wreq.tls import CertStore
+from wreq.tls import CertStore, chromium_root_store
 
 
 @pytest.mark.asyncio
@@ -48,3 +48,14 @@ async def test_alps_new_endpoint():
     async with resp:
         text = await resp.text()
         assert text is not None
+
+
+def test_chromium_root_store():
+    # The binding is always registered; on a build without the chromium-pki feature
+    # it raises rather than being absent, and on a feature build it returns a store.
+    try:
+        store = chromium_root_store()
+    except RuntimeError as exc:
+        assert "chromium-pki" in str(exc)
+    else:
+        assert isinstance(store, CertStore)


### PR DESCRIPTION
## Summary

Adds Chrome 150/151/152 to the Python `Emulation` enum, and exposes
`wreq.tls.chromium_root_store()` under a new `chromium-pki` feature.

## Details

wreq-util ships the 150-152 profiles, but the Python enum is a hand-maintained
list, so they are unreachable from Python until listed. First commit adds them.

Second commit binds `wreq_util::chromium_root_store` (feature `chromium-pki`,
a passthrough to `wreq-util/emulation-chromium-pki`) so a Python caller can
install Chrome's roots as a client's `tls_verify`, which the 150+ presets need
to verify a chain anchored to the trust anchors they request. The function is
registered unconditionally and raises `RuntimeError` on a build without the
feature, so the symbol always exists and the stub never advertises a binding
that is missing at runtime (same approach as `Proxy.unix`, and the class of bug
#582 fixed).

## Depends on

Same chain as the wreq-util PR, in order:

1. wreq #1220 (`TlsOptions::requested_trust_anchors`) merged and released.
2. 0x676e67/wreq-util#112 (150-152 TLS preset and the
   `emulation-chromium-pki` feature) merged and released.
3. `chromium-root-certs` on crates.io (or vendored) before a build with
   `chromium-pki` can be released.

The enum commit needs only 1-2. The binding builds today under the patch:

    [patch.crates-io]
    wreq = { git = "https://github.com/anatolykoptev/wreq", branch = "feat/trust-anchors" }
    wreq-util = { git = "https://github.com/lavkanos/wreq-util", branch = "feat/chrome-150-152" }

    maturin develop --features chromium-pki

## Published wheels

`chromium-pki` is not in `default` and not in the wheel matrix, so a
`pip install wreq` from PyPI does not carry it and `chromium_root_store()`
raises `RuntimeError` there, by design. Shipping Chrome 150+ roots to stock
wheels is a packaging decision (add the feature to `default` or to the wheel
build) outside this PR; this PR only turns the missing-feature case from an
`AttributeError` into a clear error.

## Tests

`tests/tls_test.py`: the populated store on a `chromium-pki` build, the
`RuntimeError` without it.
